### PR TITLE
Downgrade IMA plugin

### DIFF
--- a/StreamAMGSDK.podspec
+++ b/StreamAMGSDK.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'PlayKit' do |playkit|
     playkit.source_files  = "Source/StreamSDKPlayKit/**/*.*"
     playkit.dependency 'PlayKit', '3.28.0'
-    playkit.dependency 'PlayKit_IMA', '1.15.0'
+    playkit.dependency 'PlayKit_IMA', '1.14.0'
     playkit.dependency 'PlayKitProviders', '1.18.3'
     playkit.dependency 'PlayKitYoubora', '1.15.0'
     playkit.resource_bundles = { 'AMGPlayKitBundle' => 'Source/Media/*.*'}


### PR DESCRIPTION
Downgraded PlayKit IMA plugin to avoid to increase deployment target from 12 to 14

Got this error publishing AMG SDK to CocoaPod:
`Specs satisfying the PlayKit_IMA (= 1.15.0) dependency were found, but they required a higher minimum deployment target.`